### PR TITLE
Enable parse function information directly from .gbk file.

### DIFF
--- a/src/format_data.py
+++ b/src/format_data.py
@@ -214,6 +214,10 @@ def extract_features(this_phage, key):
     protein_id = [p[0] if p is not None else None for p in protein_id]
     phrogs = [this_CDS[i].qualifiers.get("phrog") for i in range(len(this_CDS))]
     phrogs = ["No_PHROG" if i is None else i[0] for i in phrogs]
+    functions = [this_CDS[i].qualifiers.get("function") for i in range(len(this_CDS))]
+    functions = ["unknown function" if i is None else ','.join(i) for i in functions]
+    logger.debug(phrogs)
+    logger.debug(functions)
     
     # Save all original feature qualifiers - critical for preserving information
     all_qualifiers = []
@@ -256,6 +260,7 @@ def extract_features(this_phage, key):
     return {
         "length": phage_length,
         "phrogs": phrogs,
+        "functions": functions,
         "protein_id": protein_id,
         "sense": sense,
         "position": position,
@@ -377,8 +382,13 @@ def fetch_data(input_data, gene_categories, phrog_integer, maximum_genes=False):
                 continue
 
             # integer encoding of phrog categories
-            integer = phrog_to_integer(phage_dict.get("phrogs"), phrog_integer)
+            phrogs = phrog_to_integer(phage_dict.get("phrogs"), phrog_integer)
+            functions = phrog_to_integer(phage_dict.get("functions"), phrog_integer)
+            integer = [f if p == -1 else p for p, f in zip(phrogs, functions)]
             phage_dict["categories"] = integer
+            logger.debug(phrogs)
+            logger.debug(functions)
+            logger.debug(phage_dict["categories"])
 
             # evaluate the number of categories present in the phage
             categories_present = set(integer)
@@ -895,6 +905,7 @@ def read_annotations_information():
             [phrog_integer_reverse.get(k) for k in list(category_dict.values())],
         )
     )
+    phrog_integer_category.update(phrog_integer_reverse)
     phrog_integer_category["No_PHROG"] = -1
 
     return category_dict, phrog_integer_category


### PR DESCRIPTION
To increase compatibility with other methods, I added code to read "_function_" information directly from the `.gbk` file.

If phrog id has been given, category will be assigned based on it.
If phrog id has not been given but function has been given (by other methods), category will be assigned based on it.
If both phrog id and function have not been given, category will be assigned as -1

I hope that this change will improve the compatibility of your method with other phage protein annotation methods, such as VPF-PLM (which only produces category-level annotations).