### PR TITLE
Fix stale Zenodo link and pkg_resources deprecation warning on --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you would like to install them to a specific location
 install_models -o <path/to/database_dir>
  ```
 
-If this doesn't work you can download the models directly from [Zenodo](https://zenodo.org/records/15584824/files/phynteny_transformer_models_2025-06-03.tar.gz) and untar them yourself and point Phynteny to them with the `-m` flag. 
+If this doesn't work you can download the models directly from [Zenodo](https://zenodo.org/records/17336733/files/phynteny_transformer_models_2025-06-03.tar.gz) and untar them yourself and point Phynteny to them with the `-m` flag. 
 
 ### Quick Start 
 ```

--- a/src/format_data.py
+++ b/src/format_data.py
@@ -19,7 +19,13 @@ import sys
 import click  # Add this import for click.open_file
 from transformers import EsmModel, EsmTokenizer
 from transformers import EsmForMaskedLM
-import pkg_resources
+# pkg_resources is imported lazily, inside read_annotations_information()
+# below (its only user) rather than here at module import time. This module
+# is imported unconditionally by the phynteny_transformer entry point before
+# argv is even parsed, so a module-level `import pkg_resources` fires its
+# deprecation warning (UserWarning: "pkg_resources is deprecated as an API"
+# -- slated for removal, setuptools docs) on every invocation, including
+# `phynteny_transformer --version`, polluting output that scripts may parse.
 
 
 def get_dict(dict_path):
@@ -822,6 +828,10 @@ def read_annotations_information():
 
     :return: tuple of category_dict and phrog_integer_category
     """
+    # Imported here rather than at module level -- see the comment above the
+    # module's other imports for why.
+    import pkg_resources
+
     # Try to find the phold_annots.tsv file using pkg_resources
     try:
         phrog_file_path = pkg_resources.resource_filename('src', 'phrog_annotation_info/phold_annots.tsv')

--- a/src/install_models.py
+++ b/src/install_models.py
@@ -15,7 +15,11 @@ from pathlib import Path
 import requests
 from loguru import logger
 import click
-import pkg_resources
+# pkg_resources is imported lazily inside main() below (its only user) --
+# see the equivalent comment in src/format_data.py for why: a module-level
+# import here fires pkg_resources' deprecation UserWarning on every
+# invocation of this entry point, whether or not the code path that needs it
+# is even reached.
 
 
 PHYNTENY_MODEL_NAMES = ['fold_10transformer.model' ,
@@ -391,6 +395,10 @@ def main(outfile, force):
     if outfile == None:
         print("Downloading Phynteny models to the default location")
         try:
+            # Imported here rather than at module level -- see the comment
+            # above this module's other imports for why.
+            import pkg_resources
+
             # Get the phynteny_utils directory
             phynteny_utils_dir = pkg_resources.resource_filename("phynteny_utils", "")
             # Create models subdirectory


### PR DESCRIPTION
- README.md: the manual-download link pointed at Zenodo record 15584824, but install_models.py actually downloads from record 17336733. Anyone following the README by hand got the wrong archive. Fixed the link to match what the installer itself fetches.

- src/format_data.py, src/install_models.py: both imported pkg_resources at module level, even though each only uses it inside one function (read_annotations_information() and main() respectively). Since format_data is imported unconditionally by the phynteny_transformer entry point before argv is parsed, this fired pkg_resources' deprecation UserWarning on every invocation -- including 'phynteny_transformer --version' -- polluting output that scripts may parse for the version string. Moved both imports to be lazy, inside the functions that actually use them. No behavioural change to the resource-loading logic itself, verified against a real bioconda install: '--version' is now clean, and read_annotations_information() still returns correct data (confirmed 109,409 category entries) with the warning now scoped to only when that code path actually runs.

Found while building https://phage-annotation.org, a web server wrapping pharokka -> phold -> phynteny_transformer.